### PR TITLE
Adjust slack-github-action steps in workflows

### DIFF
--- a/.github/workflows/android-l10n-integrity.yml
+++ b/.github/workflows/android-l10n-integrity.yml
@@ -46,7 +46,6 @@ jobs:
           with:
             webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
             webhook-type: incoming-webhook
-            channel-id: C08096YAV09
             payload-file-path: ./android-l10n-integrity/src/slack_payload.json
             payload-templated: true
           env:

--- a/.github/workflows/demo-slack.yml
+++ b/.github/workflows/demo-slack.yml
@@ -31,5 +31,4 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
           webhook-type: incoming-webhook
-          channel-id: C08096YAV09
           payload-file-path: "./slack-payload.json"

--- a/.github/workflows/testrail-api-tests.yml
+++ b/.github/workflows/testrail-api-tests.yml
@@ -43,9 +43,8 @@ jobs:
         id: slack-failure
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          channel-id: ${{ secrets.SLACK_MOBILE_ALERTS_SANDBOX_CHANNEL }}
           payload: |
             {
               "type": "mrkdwn",
@@ -57,9 +56,8 @@ jobs:
         id: slack-success
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          channel-id: ${{ secrets.SLACK_MOBILE_ALERTS_SANDBOX_CHANNEL }}
           payload: |
             {
               "type": "mrkdwn",


### PR DESCRIPTION
`channel-id` or `channel` is not needed when a web hook is supplied, since the web hooks were created with a target channel in Slack management


Adjusted `testrail-api-tests` to post to #mobile-alerts-tooling