### PR TITLE
add cron to run every 6 hours

### DIFF
--- a/.github/workflows/firebase-android-perf.yml
+++ b/.github/workflows/firebase-android-perf.yml
@@ -1,6 +1,9 @@
 name: Android Performance Tests in Firebase
 
 on:
+  schedule:
+    # run every 6 hours
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
adding cron to run every six hours to get a general baseline on consistency of tests based on the time of day/demand test lab has.