### PR TITLE
Add Mb/mte 4409 ingest flaky test

### DIFF
--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -168,7 +168,7 @@ jobs:
                ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }} \
                gs://mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename} \
                ios-insights/schema_flaky.json
-            shell: bash      
+        shell: bash      
             
       - name: Send Slack Notification
         run: |

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -158,7 +158,18 @@ jobs:
         run: |
             echo "Uploading file: ${csv_report_filename}"
             gsutil cp "${csv_report_filename}" gs://mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}
-                
+      
+      - name: Import CSV Report into BigQuery Flaky Test Table
+        run: |
+            echo "Importing CSV report into BigQuery Flaky Test Table"
+            bq --location=US load \
+               --source_format=CSV \
+               --skip_leading_rows=1 \
+               ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }} \
+               gs://mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename} \
+               schema_flaky.json
+            shell: bash      
+            
       - name: Send Slack Notification
         run: |
            TOTAL_TESTS=$(jq -r '.[0].total_tests' test_report.json)
@@ -176,7 +187,7 @@ jobs:
                     "type": "section", 
                     "text": { 
                         "type": "mrkdwn", 
-                        "text": ":firefox: Fennec UI Test Daily Digest for '"$YESTERDAY"'" 
+                        "text": ":firefox: iOS Fennec UI Test Daily Digest for '"$YESTERDAY"'" 
                     } 
                 },
                 {

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -167,7 +167,7 @@ jobs:
                --skip_leading_rows=1 \
                ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }} \
                gs://mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename} \
-               schema_flaky.json
+               ios-insights/schema_flaky.json
             shell: bash      
             
       - name: Send Slack Notification

--- a/ios-insights/flaky_test_details.sql
+++ b/ios-insights/flaky_test_details.sql
@@ -31,11 +31,11 @@ flagged_tests AS (
     SELECT
 	    branch,
         device,
-        DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date,
         COUNT(*) AS total_tests,
         COUNTIF(is_flaky) AS flaky_tests_count,
         ROUND(SAFE_DIVIDE(COUNTIF(is_flaky), COUNT(*)), 4) AS flaky_tests_ratio,
-        ARRAY_TO_STRING(ARRAY_AGG(CASE WHEN is_flaky THEN test_case END IGNORE NULLS), ', ') AS flaky_tests_details
+        ARRAY_TO_STRING(ARRAY_AGG(CASE WHEN is_flaky THEN test_case END IGNORE NULLS), ', ') AS flaky_tests_details,
+        DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date
     FROM flagged_tests
     GROUP BY branch, device
     ORDER BY branch, device;

--- a/ios-insights/flaky_test_details.sql
+++ b/ios-insights/flaky_test_details.sql
@@ -31,9 +31,10 @@ flagged_tests AS (
     SELECT
 	    branch,
         device,
+        DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date,
         COUNT(*) AS total_tests,
         COUNTIF(is_flaky) AS flaky_tests_count,
-        SAFE_DIVIDE(COUNTIF(is_flaky), COUNT(*)) AS flaky_tests_ratio,
+        ROUND(SAFE_DIVIDE(COUNTIF(is_flaky), COUNT(*)), 4) AS flaky_tests_ratio,
         ARRAY_TO_STRING(ARRAY_AGG(CASE WHEN is_flaky THEN test_case END IGNORE NULLS), ', ') AS flaky_tests_details
     FROM flagged_tests
     GROUP BY branch, device

--- a/ios-insights/schema_flaky.json
+++ b/ios-insights/schema_flaky.json
@@ -1,0 +1,9 @@
+[
+    {"name": "branch", "type": "STRING"},
+    {"name": "device", "type": "STRING"},
+    {"name": "total_tests", "type": "INTEGER"},
+    {"name": "flaky_test_count", "type": "INTEGER"},
+    {"name": "flaky_tests_ratio", "type": "FLOAT"},
+    {"name": "flaky_test_details", "type": "STRING"},
+    {"name": "report_date", "type": "DATE"}
+  ]


### PR DESCRIPTION
This PR add a new step in the github action to save the flaky stats into a new table in bigquery. Also fix some minor issues