### PR TITLE
Fix github actions when no data are available for the notification

### DIFF
--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -172,11 +172,11 @@ jobs:
             
       - name: Send Slack Notification
         run: |
-           TOTAL_TESTS=$(jq -r '.[0].total_tests' test_report.json)
-           FAILED_TESTS=$(jq -r '.[0].failed_tests' test_report.json)
-           FLAKY_TESTS=$(jq -r '.[0].flaky_tests' test_report.json)
-           FAILURE_RATE=$(jq -r '.[0].failure_rate' test_report.json)
-           FLAKY_RATE=$(jq -r '.[0].flaky_rate' test_report.json)
+           TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)
+           FAILED_TESTS=$(jq -r '.[0].failed_tests // 0' test_report.json)
+           FLAKY_TESTS=$(jq -r '.[0].flaky_tests // 0' test_report.json)
+           FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
+           FLAKY_RATE=$(jq -r '.[0].flaky_rate // 0' test_report.json)
            YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
            FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
          

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -225,7 +225,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Flaky Rate Yesterday: '"$FLAKY_RATE"'%" 
+                                            "text": "Flaky Rate Yesterday: '"$FLAKY_RATE"' %" 
                                         }
                                     ]
                                 },  
@@ -243,7 +243,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Failure Rate Yesterday: '"$FAILURE_RATE"'%" 
+                                            "text": "Failure Rate Yesterday: '"$FAILURE_RATE"' %" 
                                         }
                                     ]
                                 }  

--- a/ios-insights/daily_test_stats.sql
+++ b/ios-insights/daily_test_stats.sql
@@ -2,7 +2,7 @@ WITH overall AS (
     SELECT 
         COUNT(*) AS total_tests,
         COUNTIF(result = 'failed') AS failed_tests,
-        ROUND((COUNTIF(result = 'failed') / COUNT(*)) * 100, 2) AS failure_rate
+        ROUND(SAFE_DIVIDE(COUNTIF(result = 'failed'), COUNT(*)) * 100, 2) AS failure_rate
     FROM `${GCP_SA_IOS_TESTS_INSIGHTS_TABLE}`
     WHERE DATE(timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
 ),


### PR DESCRIPTION
Over the weekend, we don’t always have data available, which causes the GitHub Action to return a division by zero error. I’ve updated the query to return null in such cases, and now the notification will report 0 when there’s no data to display.