### PR TITLE
Fix the Flaky Test calculation

### DIFF
--- a/ios-insights/flaky_test_details.sql
+++ b/ios-insights/flaky_test_details.sql
@@ -10,32 +10,51 @@ WITH test_comparisons AS (
         LAG(result, 3) OVER (PARTITION BY test_case, branch, device ORDER BY timestamp) AS prev_result3
     FROM `${GCP_SA_IOS_TESTS_INSIGHTS_TABLE}`
 ),
-yesterday_tests AS (
-    SELECT *
-    FROM test_comparisons
-    WHERE DATE(timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+yesterday_failed AS (
+  -- Get distinct test cases that failed yesterday.
+  SELECT DISTINCT
+    branch,
+    device,
+    test_case,
+    result,
+    prev_result1,
+    prev_result2,
+    prev_result3
+  FROM test_comparisons
+  WHERE DATE(timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+    AND result = 'failed'
 ),
 flagged_tests AS (
-    SELECT
-	    branch,
-        device,
-        test_case,
-        result,
-    	CASE
-        	WHEN prev_result1 IS NULL OR prev_result2 IS NULL OR prev_result3 IS NULL THEN FALSE
-            WHEN (result = prev_result1 AND result = prev_result2 AND result = prev_result3) THEN FALSE
-            ELSE TRUE
-        END AS is_flaky
-    FROM yesterday_tests
+  -- For tests that failed yesterday, flag them as flaky if all three previous results exist
+  -- and are not all 'failed'
+  SELECT
+    branch,
+    device,
+    test_case,
+    CASE 
+      WHEN prev_result1 IS NULL OR prev_result2 IS NULL OR prev_result3 IS NULL THEN FALSE
+      WHEN (prev_result1 = 'failed' AND prev_result2 = 'failed' AND prev_result3 = 'failed') THEN FALSE
+      ELSE TRUE
+    END AS is_flaky
+  FROM yesterday_failed
 )
-    SELECT
-	    branch,
-        device,
-        COUNT(*) AS total_tests,
-        COUNTIF(is_flaky) AS flaky_tests_count,
-        ROUND(SAFE_DIVIDE(COUNTIF(is_flaky), COUNT(*)), 4) AS flaky_tests_ratio,
-        ARRAY_TO_STRING(ARRAY_AGG(CASE WHEN is_flaky THEN test_case END IGNORE NULLS), ', ') AS flaky_tests_details,
-        DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date
-    FROM flagged_tests
-    GROUP BY branch, device
-    ORDER BY branch, device;
+SELECT
+  branch,
+  device,
+  COUNT(DISTINCT test_case) AS total_failed_tests,  -- total tests that failed yesterday
+  COUNT(DISTINCT CASE WHEN is_flaky THEN test_case END) AS flaky_tests_count,
+  ROUND(
+    SAFE_DIVIDE(
+      COUNT(DISTINCT CASE WHEN is_flaky THEN test_case END),
+      COUNT(DISTINCT test_case)
+    ),
+    4
+  ) AS flaky_tests_ratio,
+  ARRAY_TO_STRING(
+    ARRAY_AGG(DISTINCT CASE WHEN is_flaky THEN test_case END IGNORE NULLS),
+    ', '
+  ) AS flaky_tests_details,
+  DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date
+FROM flagged_tests
+GROUP BY branch, device
+ORDER BY branch, device;


### PR DESCRIPTION
This PR fix how calculate the flaky tests. Now take into account also the test suite (I realized that some tests have the same name in different test suites) and only take into account the today's tests.