### PR TITLE
Fix flaky test calculation in bq and in slak notification

### DIFF
--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Get Daily Flaky Test Stats from BigQuery
         env:
-           GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }}
+           GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_TESTS_INSIGHTS_TABLE }}
         run: |
           envsubst < ios-insights/flaky_test_details.sql > stats_query_flaky_temp.sql
           bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json 2> error_log.txt || (cat error_log.txt && exit 1)

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -188,7 +188,7 @@ jobs:
            if [ "$TOTAL_FAILED" -eq 0 ]; then
               OVERALL_RATIO=0
            else
-              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l)
+              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l | awk '{printf "%.3f", $0}')
            fi
            FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
            FLAKY_RATE=$(jq -r '.[0].flaky_tests_ratio // 0' test_report_flaky.json)

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -172,12 +172,12 @@ jobs:
 
       - name: Get Daily Flaky Test Stats from BigQuery
         env:
-            GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }}
+           GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }}
         run: |
-            envsubst < ios-insights/flaky_test_details.sql > stats_query_flaky_temp.sql
-            bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json
-           
-            
+          envsubst < ios-insights/flaky_test_details.sql > stats_query_flaky_temp.sql
+          bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json 2> error_log.txt || (cat error_log.txt && exit 1)
+        shell: bash
+              
       - name: Send Slack Notification
         run: |
            TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -169,14 +169,22 @@ jobs:
                gs://mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename} \
                ios-insights/schema_flaky.json
         shell: bash      
+
+      - name: Get Daily Flaky Test Stats from BigQuery
+        env:
+            GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_FLAKY_TEST_TABLE }}
+        run: |
+            envsubst < ios-insights/flaky_test_details.sql > stats_query_flaky_temp.sql
+            bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json
+           
             
       - name: Send Slack Notification
         run: |
            TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)
            FAILED_TESTS=$(jq -r '.[0].failed_tests // 0' test_report.json)
-           FLAKY_TESTS=$(jq -r '.[0].flaky_tests // 0' test_report.json)
+           FLAKY_TESTS=$(jq -r '.[0].flaky_tests_count // 0' test_report_flaky.json)
            FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
-           FLAKY_RATE=$(jq -r '.[0].flaky_rate // 0' test_report.json)
+           FLAKY_RATE=$(jq -r '.[0].flaky_tests_ratio // 0' test_report_flaky.json)
            YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
            FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
            LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -175,7 +175,7 @@ jobs:
            GCP_SA_IOS_TESTS_INSIGHTS_TABLE: ${{ secrets.GCP_SA_IOS_TESTS_INSIGHTS_TABLE }}
         run: |
           envsubst < ios-insights/flaky_test_details.sql > stats_query_flaky_temp.sql
-          bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json 2> error_log.txt || (cat error_log.txt && exit 1)
+          bq query --use_legacy_sql=false --format=json < stats_query_flaky_temp.sql > test_report_flaky.json
         shell: bash
               
       - name: Send Slack Notification

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -181,8 +181,15 @@ jobs:
       - name: Send Slack Notification
         run: |
            TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)
-           FAILED_TESTS=$(jq -r '.[0].failed_tests // 0' test_report.json)
-           FLAKY_TESTS=$(jq -r '.[0].flaky_tests_count // 0' test_report_flaky.json)
+           FAILED_TESTS=$(jq '[.[] | .failed_tests | tonumber] | add' test_report.json)
+           TOTAL_FAILED=$(jq '[.[] | .total_failed_tests | tonumber] | add' test_report_flaky.json)
+           TOTAL_FLAKY=$(jq '[.[] | .flaky_tests_count | tonumber] | add' test_report_flaky.json)
+    
+           if [ "$TOTAL_FAILED" -eq 0 ]; then
+              OVERALL_RATIO=0
+           else
+              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l)
+           fi
            FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
            FLAKY_RATE=$(jq -r '.[0].flaky_tests_ratio // 0' test_report_flaky.json)
            YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
@@ -225,7 +232,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Flaky Tests Yesterday: '"$FLAKY_TESTS"'" 
+                                            "text": "Flaky Tests Yesterday: '"$TOTAL_FLAKY"'" 
                                         }
                                     ]
                                 },
@@ -234,7 +241,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Flaky Rate Yesterday: '"$FLAKY_RATE"' %" 
+                                            "text": "Flaky Rate Yesterday: '"$OVERALL_RATIO"' %" 
                                         }
                                     ]
                                 },  

--- a/ios-insights/flaky_test_details.sql
+++ b/ios-insights/flaky_test_details.sql
@@ -1,62 +1,83 @@
-WITH test_comparisons AS (
-    SELECT
-    	branch,
-        device,
-        test_case,
-        test_suite,
-        timestamp,
-        result,
-        LAG(result, 1) OVER (PARTITION BY test_case, branch, device ORDER BY timestamp) AS prev_result1,
-        LAG(result, 2) OVER (PARTITION BY test_case, branch, device ORDER BY timestamp) AS prev_result2,
-        LAG(result, 3) OVER (PARTITION BY test_case, branch, device ORDER BY timestamp) AS prev_result3
-    FROM `${GCP_SA_IOS_TESTS_INSIGHTS_TABLE}`
+WITH target_date AS (
+  -- Define yesterday as the target date.
+  SELECT DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS rpt_date
 ),
-yesterday_failed AS (
-  SELECT DISTINCT 
-    branch, 
-    device, 
+yesterday_failures AS (
+  -- Select distinct test records that failed on target_date, at the granularity of branch/device/test_suite/test_case.
+  SELECT DISTINCT
+    branch,
+    device,
     test_suite,
-    test_case, 
-    result, 
-    prev_result1, 
-    prev_result2, 
-    prev_result3
-  FROM test_comparisons
-  WHERE DATE(timestamp) = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+    test_case
+  FROM `${GCP_SA_IOS_TESTS_INSIGHTS_TABLE}`
+  WHERE DATE(timestamp) = (SELECT rpt_date FROM target_date)
     AND result = 'failed'
 ),
-flagged_tests AS (
-  SELECT
+historical AS (
+  -- Select distinct historical records for the same tests in the 3 days before target_date.
+  SELECT DISTINCT
     branch,
     device,
     test_suite,
     test_case,
+    result
+  FROM `${GCP_SA_IOS_TESTS_INSIGHTS_TABLE}`
+  WHERE DATE(timestamp) BETWEEN DATE_SUB((SELECT rpt_date FROM target_date), INTERVAL 3 DAY)
+                            AND DATE_SUB((SELECT rpt_date FROM target_date), INTERVAL 1 DAY)
+),
+flagged AS (
+  -- For each test (branch, device, test_suite, test_case) that failed yesterday,
+  -- flag it as flaky if there is at least one historical record that is not 'failed'.
+  SELECT
+    y.branch,
+    y.device,
+    y.test_suite,
+    y.test_case,
     CASE
-      WHEN prev_result1 IS NULL OR prev_result2 IS NULL OR prev_result3 IS NULL THEN FALSE
-      WHEN (prev_result1 = 'failed' AND prev_result2 = 'failed' AND prev_result3 = 'failed') THEN FALSE
-      ELSE TRUE
+      WHEN EXISTS (
+        SELECT 1 FROM historical h
+        WHERE h.branch = y.branch
+          AND h.device = y.device
+          AND h.test_suite = y.test_suite
+          AND h.test_case = y.test_case
+          AND h.result <> 'failed'
+      )
+      THEN TRUE
+      ELSE FALSE
     END AS is_flaky
-  FROM yesterday_failed
+  FROM yesterday_failures y
+),
+combined AS (
+  -- Now collapse flagged results by branch, device, and test_case (ignoring test_suite).
+  -- If the same test_case appears in multiple suites, we count it as flaky if any occurrence is flaky.
+  SELECT 
+    branch,
+    device,
+    test_case,
+    MAX(CASE WHEN is_flaky THEN 1 ELSE 0 END) AS is_flaky
+  FROM flagged
+  GROUP BY branch, device, test_case
+),
+totals AS (
+  -- Aggregate totals by branch and device:
+  -- total_failed_tests: distinct test_case count (ignoring test_suite)
+  -- flaky_tests_count: distinct test_case count flagged as flaky
+  SELECT 
+    branch,
+    device,
+    COUNT(DISTINCT test_case) AS total_failed_tests,
+    COUNT(DISTINCT CASE WHEN is_flaky = 1 THEN test_case END) AS flaky_tests_count,
+    ARRAY_TO_STRING(ARRAY_AGG(DISTINCT CASE WHEN is_flaky = 1 THEN test_case END), ', ') AS flaky_tests_details
+  FROM combined
+  GROUP BY branch, device
 )
 SELECT
   branch,
   device,
-  COUNT(DISTINCT test_case) AS total_failed_tests,
-  COUNT(DISTINCT CASE WHEN is_flaky THEN test_case END) AS flaky_tests_count,
-  ROUND(
-    SAFE_DIVIDE(
-      COUNT(DISTINCT CASE WHEN is_flaky THEN test_case END),
-      COUNT(DISTINCT test_case)
-    ),
-    4
-  ) AS flaky_tests_ratio,
-  ARRAY_TO_STRING(
-    ARRAY_AGG(DISTINCT CASE WHEN is_flaky THEN test_case END IGNORE NULLS),
-    ', '
-  ) AS flaky_tests_details,
-  DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY) AS report_date,
-  test_suite
-FROM flagged_tests
-GROUP BY branch, device, test_suite
-HAVING COUNT(DISTINCT CASE WHEN is_flaky THEN test_case END) > 0
-ORDER BY branch, device, test_suite;
+  total_failed_tests,
+  flaky_tests_count,
+  ROUND(SAFE_DIVIDE(flaky_tests_count, total_failed_tests), 4) AS flaky_tests_ratio,
+  flaky_tests_details,
+  (SELECT rpt_date FROM target_date) AS report_date
+FROM totals
+ORDER BY branch, device;

--- a/ios-insights/schema_flaky.json
+++ b/ios-insights/schema_flaky.json
@@ -5,6 +5,5 @@
     {"name": "flaky_test_count", "type": "INTEGER"},
     {"name": "flaky_tests_ratio", "type": "FLOAT"},
     {"name": "flaky_test_details", "type": "STRING"},
-    {"name": "report_date", "type": "DATE"},
-    {"name": "test_suite", "type": "STRING"}
+    {"name": "report_date", "type": "DATE"}
   ]


### PR DESCRIPTION
This PR fixes a couple of issues.
1. The query was taking into account the test suite for the calculation so the total was always 1. I need to take into account the test suite because we can have test cases with the same name in different test suites but now I aggregate the total failures for all the test suites.
2. The slack notification now print the exact ratio