### PR TITLE
Mb/mte 4544 fix null

### DIFF
--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -239,7 +239,7 @@ jobs:
                                     "elements": [ 
                                         {
                                             "type": "text", 
-                                            "text": "Tests Ran Yesterday: '"$TOTAL_TESTS"'" 
+                                            "text": "Tests Ran Yesterday: '$TOTAL_TESTS'" 
                                         }
                                     ]
                                 },
@@ -248,7 +248,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Flaky Tests Yesterday: '"$TOTAL_FLAKY"'" 
+                                            "text": "Flaky Tests Yesterday: '$TOTAL_FLAKY'" 
                                         }
                                     ]
                                 },
@@ -257,7 +257,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Flaky Rate Yesterday: '"$OVERALL_RATIO"' %" 
+                                            "text": "Flaky Rate Yesterday: '$OVERALL_RATIO' %" 
                                         }
                                     ]
                                 },  
@@ -266,7 +266,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Failed Tests Yesterday: '"$FAILED_TESTS"'" 
+                                            "text": "Failed Tests Yesterday: '$FAILED_TESTS'" 
                                         }
                                     ]
                                 }, 
@@ -275,7 +275,7 @@ jobs:
                                     "elements": [
                                         {
                                             "type": "text", 
-                                            "text": "Failure Rate Yesterday: '"$FAILURE_RATE"' %" 
+                                            "text": "Failure Rate Yesterday: '$FAILURE_RATE' %" 
                                         }
                                     ]
                                 }  
@@ -306,12 +306,6 @@ jobs:
                 }
              ]
             }'
-         
-            echo "---- SLACK PAYLOAD ----"  
-            echo "$SLACK_MESSAGE" > payload.json  
-            sed -n '20,30p' payload.json
-            jq . payload.json 
-            echo "----------------------"
 
             curl -X POST -H 'Content-type: application/json' --data "$SLACK_MESSAGE" ${{ secrets.SLACK_WEBHOOK_URL_STATS_CHANNEL }}
          

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -180,31 +180,31 @@ jobs:
               
       - name: Send Slack Notification
         run: |
-           TOTAL_TESTS=$(jq 'map(.total_tests // 0) | add // 0' test_report.json)
-           FAILED_TESTS=$(jq 'map(.failed_tests // 0) | add // 0' test_report.json)
-           TOTAL_FAILED=$(jq '[.[] | (.total_failed_tests // 0) | tonumber] | add' test_report_flaky.json)
-           TOTAL_FLAKY=$(jq '[.[] | (.flaky_tests_count // 0) | tonumber] | add' test_report_flaky.json)
+          TOTAL_TESTS=$(jq 'map(.total_tests // 0) | add // 0' test_report.json)
+          FAILED_TESTS=$(jq 'map(.failed_tests // 0) | add // 0' test_report.json)
+          TOTAL_FAILED=$(jq 'map(.total_failed_tests // 0) | add // 0' test_report_flaky.json)
+          TOTAL_FLAKY=$(jq 'map(.flaky_tests_count // 0) | add // 0' test_report_flaky.json)
 
-           FLAKY_RATE_JSON=$(jq -r '.[0]?.flaky_tests_ratio // 0' test_report_flaky.json)
-           FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE_JSON }")
+          FLAKY_RATE_JSON=$(jq -r '.[0]?.flaky_tests_ratio // 0' test_report_flaky.json)
+          FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE_JSON }")
     
-           OVERALL_RATIO=$(awk "BEGIN {
-              if ($TOTAL_FAILED == 0) { print \"0.000\" }
-              else { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }
-           }")
+          OVERALL_RATIO=$(awk "BEGIN {
+            if ($TOTAL_FAILED == 0) { print \"0.000\" }
+            else { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }
+          }")
            
-           FAILURE_RATE=$(awk "BEGIN {
-              if ($TOTAL_TESTS == 0) { print \"0.000\" }
-              else { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }
-           }")
+          FAILURE_RATE=$(awk "BEGIN {
+            if ($TOTAL_TESTS == 0) { print \"0.000\" }
+            else { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }
+          }")
            
-           YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
-           FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
-           LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"
+          YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
+          FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
+          LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"
 
-           SLACK_MESSAGE='{
-             "text": "*Firefox iOS UI Test Daily Digest - Fennec*",
-             "blocks": [
+          SLACK_MESSAGE='{
+            "text": "*Firefox iOS UI Test Daily Digest - Fennec*",
+            "blocks": [
                 { 
                     "type": "section", 
                     "text": { 

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -185,18 +185,24 @@ jobs:
           TOTAL_FAILED=$(jq 'map(.total_failed_tests // 0) | add // 0' test_report_flaky.json)
           TOTAL_FLAKY=$(jq 'map(.flaky_tests_count // 0) | add // 0' test_report_flaky.json)
 
-          FLAKY_RATE_JSON=$(jq -r '.[0]?.flaky_tests_ratio // 0' test_report_flaky.json)
-          FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE_JSON }")
-    
-          OVERALL_RATIO=$(awk "BEGIN {
-            if ($TOTAL_FAILED == 0) { print \"0.000\" }
-            else { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }
-          }")
-           
-          FAILURE_RATE=$(awk "BEGIN {
-            if ($TOTAL_TESTS == 0) { print \"0.000\" }
-            else { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }
-          }")
+          # default to zero if empty
+          TOTAL_FAILED=${TOTAL_FAILED:-0}
+          TOTAL_FLAKY=${TOTAL_FLAKY:-0}
+          TOTAL_TESTS=${TOTAL_TESTS:-0}
+          FAILED_TESTS=${FAILED_TESTS:-0}
+
+          if [ "$TOTAL_FAILED" -eq 0 ]; then
+            OVERALL_RATIO="0.000"
+          else
+            OVERALL_RATIO=$(awk "BEGIN { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }")
+          fi
+
+          # compute failure rate
+          if [ "$TOTAL_TESTS" -eq 0 ]; then
+            FAILURE_RATE="0.000"
+          else
+            FAILURE_RATE=$(awk "BEGIN { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }")
+          fi
            
           YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
           FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -180,34 +180,24 @@ jobs:
               
       - name: Send Slack Notification
         run: |
-          TOTAL_TESTS=$(jq 'map(.total_tests // 0) | add // 0' test_report.json)
-          FAILED_TESTS=$(jq 'map(.failed_tests // 0) | add // 0' test_report.json)
-          TOTAL_FAILED=$(jq 'map(.total_failed_tests // 0) | add // 0' test_report_flaky.json)
-          TOTAL_FLAKY=$(jq 'map(.flaky_tests_count // 0) | add // 0' test_report_flaky.json)
+          TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)
+          FAILED_TESTS=$(jq '[.[] | .failed_tests | tonumber] | add' test_report.json)
+          TOTAL_FAILED=$(jq '[.[] | .total_failed_tests | tonumber] | add' test_report_flaky.json)
+          TOTAL_FLAKY=$(jq '[.[] | .flaky_tests_count | tonumber] | add' test_report_flaky.json)
 
-          FLAKY_RATE=$(jq -r '.[0]?.flaky_tests_ratio? // 0' test_report_flaky.json)
-          FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE }")
-
-          OVERALL_RATIO=$(awk "BEGIN {
-            tf = $TOTAL_FAILED;
-            f  = $TOTAL_FLAKY;
-            if (tf == 0) {
-              print \"0.000\";
-            } else {
-              printf \"%.3f\", f / tf;
-            }
-          }")
-
-          FAILURE_RATE=$(awk "BEGIN {
-            t   = $TOTAL_TESTS;
-            d   = $FAILED_TESTS;
-            if (t == 0) {
-              print \"0.000\";
-            } else {
-              printf \"%.3f\", d / t;
-            }
-          }")
-
+          if [ "$TOTAL_TESTS" -eq 0 ]; then
+            FAILED_TESTS=0
+            TOTAL_FAILED=0
+            TOTAL_FLAKY=0
+            OVERALL_RATIO="0.000"
+            FAILURE_RATE="0.000"
+            FLAKY_RATE="0.000"
+          else
+            FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
+            FLAKY_RATE=$(jq -r '.[0].flaky_tests_ratio // 0' test_report_flaky.json)
+            OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l | awk '{printf "%.3f", $0}')
+          fi
+          
           YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
           FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
           LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -185,24 +185,28 @@ jobs:
           TOTAL_FAILED=$(jq 'map(.total_failed_tests // 0) | add // 0' test_report_flaky.json)
           TOTAL_FLAKY=$(jq 'map(.flaky_tests_count // 0) | add // 0' test_report_flaky.json)
 
-          # default to zero if empty
-          TOTAL_FAILED=${TOTAL_FAILED:-0}
-          TOTAL_FLAKY=${TOTAL_FLAKY:-0}
-          TOTAL_TESTS=${TOTAL_TESTS:-0}
-          FAILED_TESTS=${FAILED_TESTS:-0}
+          FLAKY_RATE=$(jq -r '.[0]?.flaky_tests_ratio? // 0' test_report_flaky.json)
+          FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE }")
 
-          if [ "$TOTAL_FAILED" -eq 0 ]; then
-            OVERALL_RATIO="0.000"
-          else
-            OVERALL_RATIO=$(awk "BEGIN { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }")
-          fi
+          OVERALL_RATIO=$(awk "BEGIN {
+            tf = $TOTAL_FAILED;
+            f  = $TOTAL_FLAKY;
+            if (tf == 0) {
+              print \"0.000\";
+            } else {
+              printf \"%.3f\", f / tf;
+            }
+          }")
 
-          # compute failure rate
-          if [ "$TOTAL_TESTS" -eq 0 ]; then
-            FAILURE_RATE="0.000"
-          else
-            FAILURE_RATE=$(awk "BEGIN { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }")
-          fi
+          FAILURE_RATE=$(awk "BEGIN {
+            t   = $TOTAL_TESTS;
+            d   = $FAILED_TESTS;
+            if (t == 0) {
+              print \"0.000\";
+            } else {
+              printf \"%.3f\", d / t;
+            }
+          }")
            
           YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
           FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -180,27 +180,23 @@ jobs:
               
       - name: Send Slack Notification
         run: |
-           TOTAL_TESTS=$(jq '[.[] | (.total_tests // 0) | tonumber] | add' test_report.json)
-           FAILED_TESTS=$(jq '[.[] | (.failed_tests // 0) | tonumber] | add' test_report.json)
+           TOTAL_TESTS=$(jq 'map(.total_tests // 0) | add // 0' test_report.json)
+           FAILED_TESTS=$(jq 'map(.failed_tests // 0) | add // 0' test_report.json)
            TOTAL_FAILED=$(jq '[.[] | (.total_failed_tests // 0) | tonumber] | add' test_report_flaky.json)
            TOTAL_FLAKY=$(jq '[.[] | (.flaky_tests_count // 0) | tonumber] | add' test_report_flaky.json)
 
-           FLAKY_RATE=$(jq -r '.[0]? .flaky_tests_ratio? // 0' test_report_flaky.json)
-           FLAKY_RATE=$(printf "%.3f" "$FLAKY_RATE")
+           FLAKY_RATE_JSON=$(jq -r '.[0]?.flaky_tests_ratio // 0' test_report_flaky.json)
+           FLAKY_RATE=$(awk "BEGIN { printf \"%.3f\", $FLAKY_RATE_JSON }")
     
-           if [ "$TOTAL_FAILED" -eq 0 ]; then
-              OVERALL_RATIO=0.000
-           else
-              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l | awk '{printf \"%.3f\", $0}')
-           fi
+           OVERALL_RATIO=$(awk "BEGIN {
+              if ($TOTAL_FAILED == 0) { print \"0.000\" }
+              else { printf \"%.3f\", $TOTAL_FLAKY / $TOTAL_FAILED }
+           }")
            
-           if [ "$TOTAL_TESTS" -eq 0 ]; then
-              FAILURE_RATE="0.000"
-           else
-              FAILURE_RATE=$(echo "scale=4; $FAILED_TESTS / $TOTAL_TESTS" \
-                      | bc -l \
-                      | awk '{printf "%.3f", $0}')
-           fi
+           FAILURE_RATE=$(awk "BEGIN {
+              if ($TOTAL_TESTS == 0) { print \"0.000\" }
+              else { printf \"%.3f\", $FAILED_TESTS / $TOTAL_TESTS }
+           }")
            
            YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
            FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -207,7 +207,7 @@ jobs:
               printf \"%.3f\", d / t;
             }
           }")
-           
+
           YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
           FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
           LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"
@@ -307,5 +307,10 @@ jobs:
              ]
             }'
          
+            echo "---- SLACK PAYLOAD ----"  
+            echo "$SLACK_MESSAGE" > payload.json  
+            jq . payload.json 
+            echo "----------------------"
+            
             curl -X POST -H 'Content-type: application/json' --data "$SLACK_MESSAGE" ${{ secrets.SLACK_WEBHOOK_URL_STATS_CHANNEL }}
          

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -309,8 +309,9 @@ jobs:
          
             echo "---- SLACK PAYLOAD ----"  
             echo "$SLACK_MESSAGE" > payload.json  
+            sed -n '20,30p' payload.json
             jq . payload.json 
             echo "----------------------"
-            
+
             curl -X POST -H 'Content-type: application/json' --data "$SLACK_MESSAGE" ${{ secrets.SLACK_WEBHOOK_URL_STATS_CHANNEL }}
          

--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -180,18 +180,28 @@ jobs:
               
       - name: Send Slack Notification
         run: |
-           TOTAL_TESTS=$(jq -r '.[0].total_tests // 0' test_report.json)
-           FAILED_TESTS=$(jq '[.[] | .failed_tests | tonumber] | add' test_report.json)
-           TOTAL_FAILED=$(jq '[.[] | .total_failed_tests | tonumber] | add' test_report_flaky.json)
-           TOTAL_FLAKY=$(jq '[.[] | .flaky_tests_count | tonumber] | add' test_report_flaky.json)
+           TOTAL_TESTS=$(jq '[.[] | (.total_tests // 0) | tonumber] | add' test_report.json)
+           FAILED_TESTS=$(jq '[.[] | (.failed_tests // 0) | tonumber] | add' test_report.json)
+           TOTAL_FAILED=$(jq '[.[] | (.total_failed_tests // 0) | tonumber] | add' test_report_flaky.json)
+           TOTAL_FLAKY=$(jq '[.[] | (.flaky_tests_count // 0) | tonumber] | add' test_report_flaky.json)
+
+           FLAKY_RATE=$(jq -r '.[0]? .flaky_tests_ratio? // 0' test_report_flaky.json)
+           FLAKY_RATE=$(printf "%.3f" "$FLAKY_RATE")
     
            if [ "$TOTAL_FAILED" -eq 0 ]; then
-              OVERALL_RATIO=0
+              OVERALL_RATIO=0.000
            else
-              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l | awk '{printf "%.3f", $0}')
+              OVERALL_RATIO=$(echo "scale=4; $TOTAL_FLAKY / $TOTAL_FAILED" | bc -l | awk '{printf \"%.3f\", $0}')
            fi
-           FAILURE_RATE=$(jq -r '.[0].failure_rate // 0' test_report.json)
-           FLAKY_RATE=$(jq -r '.[0].flaky_tests_ratio // 0' test_report_flaky.json)
+           
+           if [ "$TOTAL_TESTS" -eq 0 ]; then
+              FAILURE_RATE="0.000"
+           else
+              FAILURE_RATE=$(echo "scale=4; $FAILED_TESTS / $TOTAL_TESTS" \
+                      | bc -l \
+                      | awk '{printf "%.3f", $0}')
+           fi
+           
            YESTERDAY=$(date -d "yesterday" '+%Y-%m-%d')
            FILE_URL="https://storage.googleapis.com/mobile-reports/public/test_ios_insights/flaky_test_reports/${csv_report_filename}"
            LOOKER_URL="https://mozilla.cloud.looker.com/dashboards/2199"


### PR DESCRIPTION
This PR Fixes a couple of issues:
1. When we have no data for a day now I print 0 and 0% instead of null for flaky stats
2. Now I use the last 3 execution for the flaky stats instead of the last 3 days. This is why when we have long weekend or holiday we don't run the tests and the query failed to calculate the flaky ratio